### PR TITLE
fetchpriority added to image.tsx

### DIFF
--- a/packages/qwik-image/src/lib/image.tsx
+++ b/packages/qwik-image/src/lib/image.tsx
@@ -46,6 +46,7 @@ export interface ImageProps extends ImageAttributes {
     | 'scale-down'
     | 'inherit'
     | 'initial';
+  fetchpriority?:'low' | 'high'
 }
 
 export const ImageContext = createContextId<ImageState>('ImageContext');


### PR DESCRIPTION
**fetchpriority** is one the essential values as img attribute in order to improve page LCP.

# What is it?

- [ x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests
- [ ] Other

# Description

In order to get high score for LCP in Google Lighthouse we need set fetchpriority for hero elements. this property is essential.
